### PR TITLE
Add `container_name` for Docker services

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ docker compose up
 
 After that completes you can just navigate to http://localhost.
 
+#### Running tests
+
+We run `pytest` in the fastapi-server since it is configured properly with all Postgresql environment variables.
+
+```
+docker exec -it fastapi-server pytest
+```
+
 ### Local Setup
 
 #### Set up a new virtual environment (optional)

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: fastapi-server
     develop:
       watch:
         - path: ./src/app/
@@ -29,6 +30,7 @@ services:
       traefik.http.routers.fastapi.rule: Host(`localhost`)
       traefik.http.services.fastapi.loadbalancer.server.port: 8000
   db:
+    container_name: fastapi-db
     image: postgres
     restart: always
     environment:


### PR DESCRIPTION
 - set fastapi-server and db as container names for Docker services so we do not need to remember the container ID to run tests (or anything really)